### PR TITLE
Fix checkOnly case in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ Type: `String`
 Default value: `'build/'`
 The root options sets the base directory where metadata lives
 
-#### options.checkonly
+#### options.checkOnly
 Type: `Boolean`
 Default value: `false`
-This option sets whether this is a checkonly deploy or not
+This option sets whether this is a checkOnly deploy or not
 
 #### options.runAllTests
 Type: `Boolean`


### PR DESCRIPTION
The checkOnly option needs to be camel-case in order for it to be
expanded correctly in the antdeploy.build.xml template.
