### PR TITLE
Make timeout for retrieve/deploy configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ Type: `String`
 Default value: `'https://login.salesforce.com'`
 This option sets the api version to use for the package deployment
 
+#### options.pollWaitMillis
+Type: `Integer`
+Default value: `10000`
+This option sets the number of milliseconds to wait between polls for retrieve/deploy results.
+
+#### options.maxPoll
+Type: `Integer`
+Default value: `20`
+This option sets the number of polling attempts to be performed before aborting.
+
 #### options.apiVersion
 Type: `String`
 Default value: `'27.0'`

--- a/ant/antdeploy.build.xml
+++ b/ant/antdeploy.build.xml
@@ -5,6 +5,8 @@
       username="<%= user %>" 
       password="<%= pass %>" 
       serverurl="<%= serverurl %>" 
+      maxPoll="<%= maxPoll %>" 
+      pollWaitMillis="<%= pollWaitMillis %>" 
       deployroot="<%= root %>" 
       checkonly="<%= checkOnly %>" 
       runAllTests="<%= runAllTests %>"

--- a/ant/antretrieve.build.xml
+++ b/ant/antretrieve.build.xml
@@ -5,6 +5,8 @@
       username="<%= user %>" 
       password="<%= pass %>" 
       serverurl="<%= serverurl %>" 
+      maxPoll="<%= maxPoll %>" 
+      pollWaitMillis="<%= pollWaitMillis %>" 
       apiVersion="<%= apiVersion %>"
       retrieveTarget="<%= retrieveTarget %>"
       unpackaged="<%= unpackaged %>"

--- a/tasks/ant_sfdc.js
+++ b/tasks/ant_sfdc.js
@@ -141,6 +141,8 @@ module.exports = function(grunt) {
       root: 'build',
       apiVersion: '27.0',
       serverurl: 'https://login.salesforce.com',
+      pollWaitMillis: 10000,
+      maxPoll: 20,
       checkOnly: false,
       runAllTests: false,
       rollbackOnError: true,


### PR DESCRIPTION
Add pollWaitMillis option to configure the time to wait between
polling for retrieve/deploy results.

Add maxPoll option to configure the maximum number of times to poll for
results before timing out.
