### PR TITLE
Add the ability to specify a packageName (fullName) in package.xml

### DIFF
--- a/tasks/ant_sfdc.js
+++ b/tasks/ant_sfdc.js
@@ -104,11 +104,14 @@ module.exports = function(grunt) {
     });
   }
 
-  function buildPackageXml(pkg, version) {
+  function buildPackageXml(pkg, pkgName, version) {
     var packageXml = [
       '<?xml version="1.0" encoding="UTF-8"?>',
       '<Package xmlns="http://soap.sforce.com/2006/04/metadata">'
     ];
+    if(pkgName) {
+      packageXml.push('    <fullName>' + pkgName + '</fullName>');
+    }
     if(pkg) {
       Object.keys(pkg).forEach(function(key) {  
         var type = pkg[key];
@@ -163,7 +166,7 @@ module.exports = function(grunt) {
     var buildFile = grunt.template.process(template, { data: options });
     grunt.file.write(localTmp + '/ant/build.xml', buildFile);
 
-    var packageXml = buildPackageXml(this.data.pkg, options.apiVersion);
+    var packageXml = buildPackageXml(this.data.pkg, this.data.pkgName, options.apiVersion);
     grunt.file.write(options.root + '/package.xml', packageXml);
 
     runAnt('deploy', target, function(err, result) {
@@ -254,7 +257,7 @@ module.exports = function(grunt) {
     var buildFile = grunt.template.process(template, { data: options });
     grunt.file.write(localTmp + '/ant/build.xml', buildFile);
 
-    var packageXml = buildPackageXml(this.data.pkg, options.apiVersion);
+    var packageXml = buildPackageXml(this.data.pkg, this.data.pkgName, options.apiVersion);
     grunt.file.write(localTmp + '/package.xml', packageXml);
 
     runAnt('retrieve', target, function(err, result) {


### PR DESCRIPTION
This change makes it possible to specify a package name in package.xml. Without that, you don't get an actual package created in the Salesforce org, though all the dependencies still upload. You may want to make this change as part of a larger refactoring to the way parameters are passed to the grunt task, but I figured I would do the simplest and least verbose thing I could think of to add the functionality.
