### PR TITLE
Add ApprovalProcess to metadata.json

### DIFF
--- a/lib/metadata.json
+++ b/lib/metadata.json
@@ -44,6 +44,11 @@
     "folder": "triggers",
     "allowStar": true
   },
+  "approvalprocess": {
+    "xmlType": "ApprovalProcess",
+    "folder": "approvalProcesses",
+    "allowStar": true
+  },
   "assignmentrules": {
     "xmlType": "AssignmentRules",
     "folder": "assignmentRules",


### PR DESCRIPTION
I wasn't able to `antretrieve` Approval Processes unless I have this in this file. I couldn't find the docs, so I could be wrong about it allowing star.