### PR TITLE
Add support for CustomMetadata records

### DIFF
--- a/lib/metadata.json
+++ b/lib/metadata.json
@@ -104,6 +104,11 @@
     "folder": "labels",
     "allowStar": true
   },
+  "custommetadata": {
+    "xmlType": "CustomMetadata",
+    "folder": "customMetadata",
+    "allowStar": true
+  },
   "customobject": {
     "xmlType": "CustomObject",
     "folder": "objects",


### PR DESCRIPTION
Adds support for CustomMetadata records - https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_custommetadata.htm