### PR TITLE
Copy ad-hoc pkg to correct loc for antretrieve

### DIFF
--- a/tasks/ant_sfdc.js
+++ b/tasks/ant_sfdc.js
@@ -259,7 +259,9 @@ module.exports = function(grunt) {
 
     if (!options.existingPackage) {
       var packageXml = buildPackageXml(this.data.pkg, this.data.pkgName, options.apiVersion);
-      grunt.file.write(path.join(options.root,'/package.xml'), packageXml);
+      var rootPackagePath = path.join(options.root,'/package.xml');
+      grunt.file.write(rootPackagePath, packageXml);
+      grunt.file.copy(rootPackagePath, path.join(localTmp,'/package.xml'));
     } else {
       if(grunt.file.exists(options.root,'/package.xml')){
         grunt.file.copy(path.join(options.root,'/package.xml'), path.join(localTmp,'/package.xml'));


### PR DESCRIPTION
When specifying a package using grunt config JSON (instead of using an
existing package.xml file), the antretrieve task was not copying the
resulting package.xml file to the `localTmp` folder, which is where ant
is looking to find the package to retrieve. This corrects that, so now
the package is written to `options.root`, and then copied to `localTmp`

Fixes kevinohara80/grunt-ant-sfdc#23