### PR TITLE
Add support for Installed Packages

### DIFF
--- a/lib/metadata.json
+++ b/lib/metadata.json
@@ -209,6 +209,11 @@
     "folder": "homePageLayouts",
     "allowStar": true
   },
+  "installedpackage": {
+    "xmlType": "InstalledPackage",
+    "folder": "installedPackages",
+    "allowStar": true
+  },
   "letterhead": {
     "xmlType": "Letterhead",
     "folder": "letterhead",


### PR DESCRIPTION
Added "installedpackage" to lib/metadata.json to support Installed Packages. Is anything needed beyond those five lines?