### PR TITLE
Fix antdestroy task incorrectly generating xml files

### DIFF
--- a/ant/antdeploy.build.xml
+++ b/ant/antdeploy.build.xml
@@ -14,7 +14,8 @@
       deployroot="<%= root %>" 
       checkonly="<%= checkOnly %>" 
       runAllTests="<%= runAllTests %>"
-      rollbackOnError="<%= rollbackOnError %>">
+      rollbackOnError="<%= rollbackOnError %>"
+      ignoreWarnings="<%= ignoreWarnings %>">
       <% _.forEach(tests, function(t) { %><runTest><%= t %></runTest><% }); %>
     </sf:deploy>
   </target>

--- a/tasks/ant_sfdc.js
+++ b/tasks/ant_sfdc.js
@@ -155,7 +155,6 @@ module.exports = function(grunt) {
     grunt.file.write(path.join(localTmp,'/ant/build.xml'), buildFile);
 
     if (!options.existingPackage) {
-      var packageXml = buildPackageXml(this.data.pkg, options.apiVersion);
       var packageXml = buildPackageXml(this.data.pkg, this.data.pkgName, options.apiVersion);
       grunt.file.write(path.join(options.root,'/package.xml'), packageXml);
     }
@@ -192,6 +191,7 @@ module.exports = function(grunt) {
       checkOnly: false,
       runAllTests: false,
       rollbackOnError: true,
+      ignoreWarnings: false,
       useEnv: false
     });
 
@@ -206,10 +206,10 @@ module.exports = function(grunt) {
     var buildFile = grunt.template.process(template, { data: options });
     grunt.file.write(path.join(localTmp,'/ant/build.xml'), buildFile);
 
-    var packageXml = buildPackageXml(this.data.pkg, options.apiVersion);
+    var packageXml = buildPackageXml({}, this.data.pkgName, options.apiVersion);
     grunt.file.write(path.join(options.root,'/package.xml'), packageXml);
 
-    var destructiveXml = buildPackageXml(this.data.pkg, options.apiVersion);
+    var destructiveXml = buildPackageXml(this.data.pkg, this.data.pkgName, options.apiVersion);
     grunt.file.write(path.join(options.root,'/destructiveChanges.xml'), destructiveXml);
 
     runAnt('deploy', target, function(err, result) {

--- a/tasks/ant_sfdc.js
+++ b/tasks/ant_sfdc.js
@@ -139,6 +139,7 @@ module.exports = function(grunt) {
       checkOnly: false,
       runAllTests: false,
       rollbackOnError: true,
+      ignoreWarnings: false,
       useEnv: false,
       existingPackage: false
     });


### PR DESCRIPTION
The calls to `buildPackageXml` incorrectly passed the apiVersion as the second parameter, rather than the third parameter.
The generated `package.xml` also should have been empty, otherwise SFDC does a redundant deploy of those files before deleting them.

I have also added support for `ignoreWarnings`, which improves the behaviour of `antdestroy`, so that subsequent destructive deployments can list metadata that has already been deleted in the target org without the deploy failing.
This is helpful for when destructive changes are checked in to version control or are otherwise being incremented on.