### PR TITLE
Add support for deploying archives

### DIFF
--- a/ant/antdeploy.build.xml
+++ b/ant/antdeploy.build.xml
@@ -10,8 +10,12 @@
       <% } %>
       serverurl="<%= serverurl %>" 
       maxPoll="<%= maxPoll %>" 
-      pollWaitMillis="<%= pollWaitMillis %>" 
+      pollWaitMillis="<%= pollWaitMillis %>"
+      <% if(zipFile) {%>
+      zipFile="<%= zipFile %>"
+      <% } else { %>
       deployroot="<%= root %>" 
+      <% } %>
       checkonly="<%= checkOnly %>" 
       runAllTests="<%= runAllTests %>"
       rollbackOnError="<%= rollbackOnError %>"

--- a/tasks/ant_sfdc.js
+++ b/tasks/ant_sfdc.js
@@ -132,6 +132,7 @@ module.exports = function(grunt) {
       token: false,
       sessionid: false,
       root: './build',
+	  zipFile: false,
       apiVersion: '29.0',
       serverurl: 'https://login.salesforce.com',
       pollWaitMillis: 10000,

--- a/tasks/ant_sfdc.js
+++ b/tasks/ant_sfdc.js
@@ -474,4 +474,25 @@ module.exports = function(grunt) {
 
   });
 
+  grunt.registerMultiTask('antpackage', 'Build package.xml for directory.', function() {
+
+    makeLocalTmp();
+
+    var done = this.async();
+    var target = this.target.green;
+
+    var options = this.options({
+      root: './build',
+      apiVersion: '29.0',
+    });
+
+    grunt.log.writeln('Building package.xml -> ' + options.root + '/package.xml');
+
+	var packageXml = buildPackageXml(this.data.pkg, this.data.pkgName, options.apiVersion);
+	grunt.file.write(path.join(options.root,'/package.xml'), packageXml);
+
+	done();
+
+  });
+
 };


### PR DESCRIPTION
This was mentioned in a closed issue (#36). Instead of adding full support for bundling a root directory before deploying, this just adds support to pass `zipFile` to the `antdeploy` template.