### PR TITLE
Added new ant-salesforce.jar (v38.0) and new testLevel build parameter

### DIFF
--- a/ant/antdeploy.build.xml
+++ b/ant/antdeploy.build.xml
@@ -19,6 +19,7 @@
       checkonly="<%= checkOnly %>" 
       runAllTests="<%= runAllTests %>"
       rollbackOnError="<%= rollbackOnError %>"
+      testLevel="<%= testLevel %>"
       ignoreWarnings="<%= ignoreWarnings %>">
       <% _.forEach(tests, function(t) { %><runTest><%= t %></runTest><% }); %>
     </sf:deploy>

--- a/tasks/ant_sfdc.js
+++ b/tasks/ant_sfdc.js
@@ -32,7 +32,8 @@ var antdeployOpts = {
   rollbackOnError: true,
   ignoreWarnings: false,
   useEnv: false,
-  existingPackage: false
+  existingPackage: false,
+  testLevel: "RunLocalTests"
 }
 
 function lookupMetadata(key) {


### PR DESCRIPTION
Recently I was trying to use grunt-ant-sfdc deploying to sandbox and running all local test. I found that it is impossible in current version of ant-salesforce.jar
This commit update that file and add extra parameter **testLevel**, with "RunLocalTests" as default value 
Feel free to leave comments/feedback