### PR TITLE
Add support for global value sets

### DIFF
--- a/lib/metadata.json
+++ b/lib/metadata.json
@@ -194,6 +194,11 @@
     "folder": ["documents","email","reports","dashboards"],
     "allowStar": false
   },
+  "globalvalueset": {
+      "xmlType": "GlobalValueSet",
+      "folder": "globalValueSets",
+      "allowStar": true
+  },
   "group": {
     "xmlType": "Group",
     "folder": "groups",


### PR DESCRIPTION
For those using API `38.0` for their deployments, this ensures that `GlobalValueSet` metadata can be deployed