### PR TITLE
Support FeatureParameter metadata types

### DIFF
--- a/lib/metadata.json
+++ b/lib/metadata.json
@@ -174,6 +174,21 @@
     "folder": "escalationRules",
     "allowStar": true
   },
+  "featureparameterboolean": {
+    "xmlType": "FeatureParameterBoolean",
+    "folder": "featureParameters",
+    "allowStar": true
+  },
+  "featureparameterdate": {
+    "xmlType": "FeatureParameterDate",
+    "folder": "featureParameters",
+    "allowStar": true
+  },
+  "featureparameterinteger": {
+    "xmlType": "FeatureParameterInteger",
+    "folder": "featureParameters",
+    "allowStar": true
+  },
   "fieldset": {
     "xmlType": "FieldSet",
     "folder": "objects",


### PR DESCRIPTION
Adds support for the three metadata types used by the Feature Management Application:

- FeatureParameterBoolean
- FeatureParameterDate
- FeatureParameterInteger