### PR TITLE
The options now support the packageNames attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ Type: `Boolean`
 Default value: `false`
 This option will tell the task to assume a package.xml file exists in the `root` folder. If this option is `true` the `pkg` data provided to the task will be ignored and a new package.xml file will not be generated. This allows you to reuse a package.xml file that may be present in your project.
 
+#### options.packageNames
+Type: `String`
+This options will retrieve all components from a package from Salesforce with the same name. If populated, `options.existingPackage` and `pkg` will be ignored. See https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_deploying_ant_retrieveCode.htm
+
 ### Usage Examples
 
 #### Single Org Retrieve

--- a/ant/antretrieve.build.xml
+++ b/ant/antretrieve.build.xml
@@ -16,7 +16,11 @@
       pollWaitMillis="<%= pollWaitMillis %>" 
       apiVersion="<%= apiVersion %>"
       retrieveTarget="<%= retrieveTarget %>"
+      <% if(packageNames) { %>
+      packageNames="<%= packageNames %>"
+      <% } else { %>
       unpackaged="<%= unpackaged %>"
+      <% } %>
       unzip="<%= unzip %>">
     </sf:retrieve >
   </target>

--- a/tasks/ant_sfdc.js
+++ b/tasks/ant_sfdc.js
@@ -256,16 +256,26 @@ module.exports = function(grunt) {
     var buildFile = grunt.template.process(template, { data: options });
     grunt.file.write(path.join(localTmp,'/ant/build.xml'), buildFile);
 
-    if (!options.existingPackage) {
-      var packageXml = buildPackageXml(this.data.pkg, this.data.pkgName, options.apiVersion);
-      var rootPackagePath = path.join(options.root,'/package.xml');
-      grunt.file.write(rootPackagePath, packageXml);
-      grunt.file.copy(rootPackagePath, path.join(localTmp,'/package.xml'));
+    // If the tasks specifies a pkgName in the options, then use packageNames attribute
+    // instead of unpackaged attribute. This means we do not need to create/have a package.xml
+    if(options.packageNames){
+      if(!grunt.file.exists(options.retrieveTarget)){
+        grunt.log.writeln(options.retrieveTarget, "did not exist. Creating directory.");
+        grunt.file.mkdir(options.retrieveTarget);
+      }
+    // Otherwise, create/find the package.xml
     } else {
-      if(grunt.file.exists(options.root,'/package.xml')){
-        grunt.file.copy(path.join(options.root,'/package.xml'), path.join(localTmp,'/package.xml'));
+      if (!options.existingPackage) {
+        var packageXml = buildPackageXml(this.data.pkg, this.data.pkgName, options.apiVersion);
+        var rootPackagePath = path.join(options.root,'/package.xml');
+        grunt.file.write(rootPackagePath, packageXml);
+        grunt.file.copy(rootPackagePath, path.join(localTmp,'/package.xml'));
       } else {
-        grunt.log.error('No Package.xml file found in ' + options.root);
+        if(grunt.file.exists(options.root,'/package.xml')){
+          grunt.file.copy(path.join(options.root,'/package.xml'), path.join(localTmp,'/package.xml'));
+        } else {
+          grunt.log.error('No Package.xml file found in ' + options.root);
+        }
       }
     }
 


### PR DESCRIPTION
antretrieve now can retrieve packages with just the package fullname.

Resubmitted a merge request (see pull [53](https://github.com/kevinohara80/grunt-ant-sfdc/pull/53) ) since it has falling behind of master.

This is related to feature request #52 