### PR TITLE
Handle when packageNames is undefined

### DIFF
--- a/ant/antretrieve.build.xml
+++ b/ant/antretrieve.build.xml
@@ -16,7 +16,7 @@
       pollWaitMillis="<%= pollWaitMillis %>" 
       apiVersion="<%= apiVersion %>"
       retrieveTarget="<%= retrieveTarget %>"
-      <% if(packageNames) { %>
+      <% if (typeof packageNames != 'undefined' && packageNames) { %>
       packageNames="<%= packageNames %>"
       <% } else { %>
       unpackaged="<%= unpackaged %>"


### PR DESCRIPTION
The line that checks for truthiness of the packageNames var throws an error if the var is undefined. This commit adds an extra check for undefined before checking for truthiness.